### PR TITLE
Add optimize settings to reduce release size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,9 @@ tui = []
 
 [package.metadata.deb]
 depends = "libssl1.1"
+
+[profile.release]
+strip = true
+opt-level = "z"
+lto = true
+codegen-units = 1


### PR DESCRIPTION
The release size on Windows down from `6151 KB` to `3469 KB` (`43.56%` less size) 🛐 